### PR TITLE
get-categories-and-fields format change

### DIFF
--- a/backend/api_callers.py
+++ b/backend/api_callers.py
@@ -1,0 +1,51 @@
+from typing import Literal
+
+import requests
+
+BASE_URL = "http://127.0.0.1:5000/api"
+
+
+def server_running() -> bool:
+    response = requests.get(f"{BASE_URL}/ping/")
+    return response.status_code == 200
+
+
+def complain_if_server_not_running():
+    if not server_running():
+        raise Exception("Couldn't connect to the backend. Is it running?")
+
+
+def create_wildlife(name: str, scientific_name: str, category_id: int,
+                    custom_field_values: dict[str, str | int]) -> int:
+    complain_if_server_not_running()
+    response = requests.post(f"{BASE_URL}/create-wildlife/",
+                             data={"name": name, "scientific_name": scientific_name, "category_id": category_id,
+                                   **custom_field_values})
+    if response.status_code == 201:
+        return response.json()["wildlife_id"]
+    else:
+        raise Exception(
+            f"Failed to create wildlife (server returned {response.status_code}). Full response: {response.text}")
+
+
+def create_field(name: str, type: Literal["INTEGER", "TEXT"], category_ids: list[int]):
+    complain_if_server_not_running()
+    response = requests.post(f"{BASE_URL}/create-field/",
+                             data={"name": name, "type": type, "category_id": category_ids})
+    if response.status_code == 201:
+        return response.json()["field_id"]
+    else:
+        raise Exception(f"Failed to create field (server returned {response.status_code}). Full response: {response.text}")
+
+
+def create_category(name: str, parent_id: int | None = None) -> int:
+    complain_if_server_not_running()
+    data = {"name": name, "parent_id": parent_id}
+    if parent_id:
+        data["parent_id"] = parent_id
+    response = requests.post(f"{BASE_URL}/create-category/", data=data)
+    if response.status_code == 201:
+        return response.json()["category_id"]
+    else:
+        raise Exception(
+            f"Failed to create category (server returned {response.status_code}). Full response: {response.text}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,12 +6,9 @@ app = Flask(__name__)
 CORS(app)  # Enable Cross-Origin Resource Sharing for all routes
 
 
-@app.route("/api")
+@app.route("/api", methods=["GET"])
 def hello_world():
     """
-    Simple endpoint to check if the API is running.
-    Returns a greeting message.
-
     Example request:
     GET /api
     
@@ -19,6 +16,11 @@ def hello_world():
     "Hello, from Flask!"
     """
     return 'Hello, from Flask!'
+
+
+@app.route("/api/ping/", methods=["GET"])
+def ping():
+    return "Pong", 200
 
 
 def get_subcategory_ids(top_level_category_ids):


### PR DESCRIPTION
All categories are now at the top level of the "categories" dict, and "subcategories" is now just a list of category IDs as opposed to a list of full category objects