### PR TITLE
Backend - Multi-database initialization with family field seeding

### DIFF
--- a/backend/app/db_helpers.py
+++ b/backend/app/db_helpers.py
@@ -166,3 +166,62 @@ def init_db():
     conn.commit()
     conn.close()
     print("[DB DEBUG] Database initialized!")
+
+
+def _seed_family_field(conn):
+    """Ensure a 'family' TEXT field exists and is associated with all root categories."""
+    cursor = conn.cursor()
+    cursor.execute("SELECT id FROM Fields WHERE name = 'family'")
+    row = cursor.fetchone()
+    if row is None:
+        cursor.execute("INSERT INTO Fields (name, type) VALUES ('family', 'TEXT')")
+        family_field_id = cursor.lastrowid
+    else:
+        family_field_id = row[0] if isinstance(row, tuple) else row["id"]
+
+    # Associate with all root categories that aren't already linked
+    cursor.execute("SELECT id FROM Categories WHERE parent_id IS NULL")
+    root_categories = cursor.fetchall()
+    for cat in root_categories:
+        cat_id = cat[0] if isinstance(cat, tuple) else cat["id"]
+        cursor.execute(
+            "SELECT 1 FROM FieldsToCategories WHERE field_id = ? AND category_id = ?",
+            (family_field_id, cat_id),
+        )
+        if cursor.fetchone() is None:
+            cursor.execute(
+                "INSERT INTO FieldsToCategories (field_id, category_id) VALUES (?, ?)",
+                (family_field_id, cat_id),
+            )
+    conn.commit()
+
+
+EXPECTED_DATASETS = ["butterflies", "dragonflies", "wildflowers"]
+
+
+def init_all_dbs():
+    """Initialize schema and seed the 'family' field for every dataset database."""
+    sql_path = os.path.join(THIS_FOLDER, "create.sql")
+    with open(sql_path, "r") as sql_file:
+        sql_script = sql_file.read()
+
+    # Ensure the data folder and expected dataset directories exist
+    os.makedirs(DATA_FOLDER, exist_ok=True)
+    for dataset in EXPECTED_DATASETS:
+        dataset_dir = os.path.join(DATA_FOLDER, dataset)
+        os.makedirs(dataset_dir, exist_ok=True)
+        os.makedirs(os.path.join(dataset_dir, "uploaded_images"), exist_ok=True)
+
+    for entry in os.scandir(DATA_FOLDER):
+        if not entry.is_dir():
+            continue
+        db_path = os.path.join(entry.path, "database.db")
+        print(f"[DB DEBUG] Initializing database for dataset '{entry.name}': {db_path}")
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        cursor = conn.cursor()
+        cursor.executescript(sql_script)
+        conn.commit()
+        _seed_family_field(conn)
+        conn.close()
+        print(f"[DB DEBUG] Dataset '{entry.name}' initialized with 'family' field.")

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,7 @@ from app import create_app
 from app import db_helpers
 
 
-db_helpers.init_db()
+db_helpers.init_all_dbs()
 app = create_app()
 
 if __name__ == "__main__":

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,18 +1,23 @@
 import pytest
 import sys
 import os
+import tempfile
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from app import create_app
+from app import db_helpers
 @pytest.fixture
 def client():
+    db_fd, db_path = tempfile.mkstemp(suffix='.db')
     app = create_app({
         'TESTING': True,
-        'DATABASE': ':memory:',  # Use in-memory SQLite DB
-        'IMAGE_UPLOAD_FOLDER': '/tmp/test_uploaded_images',  # Use a temp folder
+        'DATABASE': db_path,
+        'IMAGE_UPLOAD_FOLDER': '/tmp/test_uploaded_images',
     })
 
     with app.test_client() as client:
         with app.app_context():
-            # Initialize your schema here if needed
-            pass
+            db_helpers.init_db()
         yield client
+
+    os.close(db_fd)
+    os.unlink(db_path)

--- a/frontend26/src/pages/WildlifeDBs/WildlifeDB.jsx
+++ b/frontend26/src/pages/WildlifeDBs/WildlifeDB.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext, useMemo } from "react";
 import { AdminContext } from "../../services/adminContext";
 import { NavLink } from "react-router-dom";
 import apiService from "../../services/apiService";
@@ -49,8 +49,9 @@ function Result({ wildlifeType, id, name, sub, image }) {
   );
 }
 
-function FamilyFilter({ family, genera, openFamilies, setOpenFamilies }) {
+function FamilyFilter({ family, genera, openFamilies, setOpenFamilies, selectedFamilies, toggleFamily, selectedGenera, toggleGenus }) {
   const isOpen = openFamilies.has(family);
+  const isFamilyChecked = selectedFamilies.has(family);
 
   const toggle = () =>
     setOpenFamilies(prev => {
@@ -66,7 +67,13 @@ function FamilyFilter({ family, genera, openFamilies, setOpenFamilies }) {
         className="flex items-center gap-2 px-1.5 py-1 rounded cursor-pointer text-sand-600 hover:bg-sand-200 transition-colors select-none"
         onClick={toggle}
       >
-        <input type="checkbox" className="accent-sand-400 w-3.5 h-3.5 shrink-0" onClick={e => e.stopPropagation()} />
+        <input
+          type="checkbox"
+          className="accent-sand-400 w-3.5 h-3.5 shrink-0"
+          checked={isFamilyChecked}
+          onChange={() => toggleFamily(family)}
+          onClick={e => e.stopPropagation()}
+        />
         <span className="font-serif text-sm">{family}</span>
         <svg
           className={`ml-auto w-3.5 h-3.5 shrink-0 transition-transform duration-200 ${isOpen ? "rotate-90" : ""}`}
@@ -92,7 +99,12 @@ function FamilyFilter({ family, genera, openFamilies, setOpenFamilies }) {
               key={genus}
               className="flex items-center gap-2 cursor-pointer text-sand-400 italic font-serif text-sm hover:bg-sand-200 rounded px-1 py-0.5 transition-colors select-none"
             >
-              <input type="checkbox" className="accent-sand-400 w-3.5 h-3.5 shrink-0 not-italic" />
+              <input
+                type="checkbox"
+                className="accent-sand-400 w-3.5 h-3.5 shrink-0 not-italic"
+                checked={selectedGenera.has(genus)}
+                onChange={() => toggleGenus(genus)}
+              />
               {genus}
             </label>
           ))}
@@ -105,6 +117,9 @@ function FamilyFilter({ family, genera, openFamilies, setOpenFamilies }) {
 export function WildlifeDB({ type, label, heroImage, heroPosition = "50% 50%", title }) {
   const [search, setSearch] = useState("");
   const [wildlife, setWildlife] = useState([]);
+  const [openFamilies, setOpenFamilies] = useState(new Set());
+  const [selectedFamilies, setSelectedFamilies] = useState(new Set());
+  const [selectedGenera, setSelectedGenera] = useState(new Set());
   const { admin } = useContext(AdminContext);
 
   useEffect(() => {
@@ -119,9 +134,46 @@ export function WildlifeDB({ type, label, heroImage, heroPosition = "50% 50%", t
     fetchData();
   }, [type]);
 
-  const filtered = wildlife.filter(w =>
-    w.name.toLowerCase().includes(search.toLowerCase())
-  );
+  // Build a map of family -> Set of genera from field_values
+  const familyMap = useMemo(() => {
+    const map = new Map();
+    for (const w of wildlife) {
+      const familyField = (w.field_values || []).find(fv => fv.name.toLowerCase() === "family");
+      const familyName = familyField ? familyField.value : null;
+      if (!familyName) continue;
+      if (!map.has(familyName)) map.set(familyName, new Set());
+      const genus = w.scientific_name ? w.scientific_name.split(" ")[0] : null;
+      if (genus) map.get(familyName).add(genus);
+    }
+    return new Map([...map.entries()].sort((a, b) => a[0].localeCompare(b[0])));
+  }, [wildlife]);
+
+  const toggleFamily = (family) =>
+    setSelectedFamilies(prev => {
+      const next = new Set(prev);
+      next.has(family) ? next.delete(family) : next.add(family);
+      return next;
+    });
+
+  const toggleGenus = (genus) =>
+    setSelectedGenera(prev => {
+      const next = new Set(prev);
+      next.has(genus) ? next.delete(genus) : next.add(genus);
+      return next;
+    });
+
+  const hasFilters = selectedFamilies.size > 0 || selectedGenera.size > 0;
+
+  const filtered = wildlife.filter(w => {
+    if (!w.name.toLowerCase().includes(search.toLowerCase())) return false;
+    if (!hasFilters) return true;
+    const familyField = (w.field_values || []).find(fv => fv.name.toLowerCase() === "family");
+    const familyName = familyField ? familyField.value : null;
+    const genus = w.scientific_name ? w.scientific_name.split(" ")[0] : null;
+    if (selectedGenera.size > 0 && genus && selectedGenera.has(genus)) return true;
+    if (selectedFamilies.size > 0 && familyName && selectedFamilies.has(familyName)) return true;
+    return false;
+  });
 
   return (
     <>
@@ -155,6 +207,19 @@ export function WildlifeDB({ type, label, heroImage, heroPosition = "50% 50%", t
             <h5 className="font-['Montserrat',sans-serif] text-sand-300 text-xs font-semibold tracking-widest uppercase mb-5 ml-2">
               Filters
             </h5>
+            {[...familyMap.entries()].map(([family, genera]) => (
+              <FamilyFilter
+                key={family}
+                family={family}
+                genera={genera}
+                openFamilies={openFamilies}
+                setOpenFamilies={setOpenFamilies}
+                selectedFamilies={selectedFamilies}
+                toggleFamily={toggleFamily}
+                selectedGenera={selectedGenera}
+                toggleGenus={toggleGenus}
+              />
+            ))}
           </aside>
 
           {/* Main content */}


### PR DESCRIPTION
**Changes:**
- db_helpers.py: Added _seed_family_field() to ensure a "family" field exists and is linked to root          
  categories, EXPECTED_DATASETS list, and init_all_dbs() to initialize schema + seed family field for every    
  dataset (butterflies, dragonflies, wildflowers)                                                              
- main.py: Switched from init_db() to init_all_dbs() so all dataset databases get initialized at startup     
                                                                                